### PR TITLE
[Documentation] Fix an array of `searches` in the Bulk Search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,13 @@ If you have high volume of searches (e.g., >= 1 million) and they don't need to 
 client = SerpApi::Client.new api_key: 'secret_api_key', async: true
 
 searches = [
-  engine: "google", q: "coffee",
-  engine: "google", q: "tea",
-  engine: "google", q: "hot chocolate milk",
-  ...
+  { engine: "google", q: "coffee" },
+  { engine: "google", q: "tea" },
+  { engine: "google", q: "hot chocolate milk" },
+  # ...
 ]
 
+# Submit async searches
 async_searches = searches.map do |search|
   async_search = client.search search
   async_search


### PR DESCRIPTION
This PR makes an [example usage of Bulk Search API](https://github.com/serpapi/serpapi-ruby/blob/master/README.md#bulk-search-api) copy-pasteable.