### PR TITLE
Add current status disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SerpApi Ruby Library
 
+> This library is still in beta. You can use our [Google Search Results Ruby SDK](https://github.com/serpapi/google-search-results-ruby) in production.
+
 [![Gem Version](https://badge.fury.io/rb/serpapi.svg)](https://badge.fury.io/rb/serpapi) [![serpapi-ruby](https://github.com/serpapi/serpapi-ruby/actions/workflows/ci.yml/badge.svg)](https://github.com/serpapi/serpapi-ruby/actions/workflows/ci.yml)  [![serpapi-ruby-alternative](https://github.com/serpapi/serpapi-ruby/actions/workflows/sanity_alt.yml/badge.svg)](https://github.com/serpapi/serpapi-ruby/actions/workflows/sanity_alt.yml) [![serpapi-ruby-sanity-1](https://github.com/serpapi/serpapi-ruby/actions/workflows/sanity_1.yml/badge.svg)](https://github.com/serpapi/serpapi-ruby/actions/workflows/sanity_1.yml) [![serpapi-ruby-sanity-2](https://github.com/serpapi/serpapi-ruby/actions/workflows/sanity_2.yml/badge.svg)](https://github.com/serpapi/serpapi-ruby/actions/workflows/sanity_2.yml)
 
 Integrate search data into your Ruby application. This library is the official wrapper for SerpApi (https://serpapi.com).

--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ pp results[:images_results]
 
 ## Migration quick guide
 
-if you were already using (google-search-results-ruby gem)[https://github.com/serpapi/google-search-results-ruby], here are the changes.
+if you were already using [google-search-results-ruby gem](https://github.com/serpapi/google-search-results-ruby), here are the changes.
 
 ```
 # load library


### PR DESCRIPTION
It addresses this issue: https://github.com/serpapi/serpapi-ruby/issues/3

- Fix markdown typo for link
- Add beta-disclaimer on the readme
