### PR TITLE
Move changelog information into separate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+ * [2026-02-23] 1.0.3 Enhance error object #16
+ * [2025-11-17] 1.0.2 Implement `inspect` functions for client #13
+ * [2025-07-18] 1.0.1 Add support for old Ruby versions (2.7, 3.0)
+ * [2025-07-01] 1.0.0 Full API support

--- a/README.md
+++ b/README.md
@@ -1099,11 +1099,6 @@ Ruby versions validated by Github Actions:
  - 3.4
  * doc: [Github Actions.](https://github.com/serpapi/serpapi-ruby/actions/workflows/ci.yml)
 
-## Change logs
- * [2025-11-17] 1.0.2 Implement `inspect` functions for client
- * [2025-07-18] 1.0.1 Add support for old Ruby versions (2.7, 3.0)
- * [2025-07-01] 1.0.0 Full API support
-
 ## Developer Guide
 ### Key goals
  - Brand centric instead of search engine based


### PR DESCRIPTION
This commit moves the changelog information from the `README.md` to a separate `CHANGELOG.md` file. This is a common practice:
1. pry - https://github.com/pry/pry/blob/master/CHANGELOG.md
2. nokogiri - https://github.com/sparklemotion/nokogiri/blob/main/CHANGELOG.md
3. colorize - https://github.com/fazibear/colorize/blob/master/CHANGELOG.md
4. rubocop - https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md
