### PR TITLE
Decouple performance info from README

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,40 @@
+## Performance Comparison
+
+### Ruby 4.0.0 vs 3.4.4 vs Ruby 2.7.8 Performance
+
+| Metric | Ruby 2.7.8 | Ruby 3.4.4 | Ruby 4.0.0 | Improvement (3.4.4 vs 2.7.8) | Improvement (4.0.0 vs 3.4.4) |
+|--------|------------|------------|------------|------------------------------|------------------------------|
+| **SerpApi Non-Persistent** | 100.93 req/s | 114.97 req/s | 120.09 req/s | **+13.9%** | **+4.5%** |
+| **SerpApi Persistent** | 226.82 req/s | 255.07 req/s | 296.05 req/s | **+12.4%** | **+16.1%** |
+| **HTTP.rb Non-Persistent** | 270.62 req/s | 294.01 req/s | 319.81 req/s | **+8.6%** | **+8.8%** |
+| **HTTP.rb Persistent** | 347.04 req/s | 570.95 req/s | 456.93 req/s | **+64.5%** | **-20.0%** |
+
+#### Thread Pool Demo
+
+Here's a benchmark of `demo/demo_thread_pool.rb`:
+
+** Benchmark Ruby 3.4.8 vs Ruby 4.0.0 **
+
+benchmark: (demo/demo_thread_pool.rb)
+
+| ruby | runtime (s) | thread | time/thread (s) |
+|------|------------:|-------:|----------------:|
+| 3.4.8 | 0.018644 | 4 | 0.004661 |
+| 4.0.0 | 0.017302 | 4 | 0.004326 |
+
+Ruby 4.0.0 shows a slight improvement over Ruby 3.4.8, but the difference is not significant using thread.
+Ractor could be considered for a more efficient use of resources but it's still in the experimental stage.
+
+Note: in this benchmark, `thread == HTTP connections`.
+
+### Key Takeaways
+
+1. **Upgrade to Ruby 3.4.4**: Clear performance benefits across all scenarios
+2. **Use Persistent Connections**: 2x+ performance improvement in most cases
+3. **HTTP.rb Performance**: Particularly benefits from Ruby 3.4.4 with persistent connections
+4. **SerpApi Optimization**: Shows consistent ~2.2x improvement with persistent connections regardless of Ruby version
+5. **Ruby 4.0.0 Performance**: Shows mixed results with some regressions compared to 3.4.4, particularly for HTTP.rb persistent connections. Ruby 4.0.0 was just released for Christmas 2025, and HTTP.rb has not been optimized for it yet.
+
+The older library (google-search-results-ruby) was performing at 55 req/s on Ruby 2.7.8, which is 2x slower than the current version (serpapi-ruby) on Ruby 3.4.4 or 4.0.0. 
+
+**Context** This benchmark was performed on warmup search results using a MacBook Pro 2025 connected via Wi-Fi 6.0 home network on AT&T fiber from Austin, TX (no network optimization).

--- a/README.md
+++ b/README.md
@@ -16,21 +16,22 @@ Query a vast range of data at scale, including web search results, flight schedu
 
 ## Installation
 
-Ruby 2.7 and higher are supported. To achieve an optimal performance, the latest version is recommended. Check 2.7.8 vs 3.4.4 [performance comparison](#Performance-Comparison).
+### RubyGems
 
-Other versions, such as Ruby 1.9, Ruby 2.x, and JRuby, are compatible with [legacy SerpApi library](https://github.com/serpapi/google-search-results-ruby), which is still supported. To upgrade to the latest library, check our [migration guide](#Migration-quick-guide).
-
-### Bundler
-```ruby
-gem 'serpapi', '~> 1.0', '>= 1.0.3'
-```
-
-### Gem 
 ```bash
 $ gem install serpapi
 ```
 
-[Ruby Gem page](https://rubygems.org/gems/serpapi/)
+[RubyGems page](https://rubygems.org/gems/serpapi/)
+
+Ruby 2.7 and higher are supported. Other versions, such as Ruby 1.9, Ruby 2.x, and JRuby, are compatible with [legacy SerpApi library](https://github.com/serpapi/google-search-results-ruby), which is still supported. To upgrade to the latest library, check our [migration guide](#Migration-quick-guide).
+
+### Bundler
+
+```ruby
+# Gemfile
+gem 'serpapi', '~> 1.0', '>= 1.0.3'
+```
 
 ## Simple Usage
 
@@ -196,22 +197,6 @@ Note: `gem install connection_pool` to run this example.
 * Improved performance by avoiding the overhead of creating and destroying connections for each request.
 * Efficient use of resources by sharing connections among multiple threads.
 * Concurrency and parallelism, allowing multiple requests to be processed simultaneously.
-
-benchmark: (demo/demo_thread_pool.rb)
-
-** Benchmark Ruby 3.4.8 vs Ruby 4.0.0 **
-
-benchmark: (demo/demo_thread_pool.rb)
-
-| ruby | runtime (s) | thread | time/thread (s) |
-|------|------------:|-------:|----------------:|
-| 3.4.8 | 0.018644 | 4 | 0.004661 |
-| 4.0.0 | 0.017302 | 4 | 0.004326 |
-
-Ruby 4.0.0 shows a slight improvement over Ruby 3.4.8, but the difference is not significant using thread. 
-Ractor could be considered for a more efficient use of resources but it's still in the experimental stage.
-
-Note: in this benchmark, `thread == HTTP connections`.
 
 ### Real world search without persistency
 
@@ -1008,28 +993,6 @@ pp results[:organic_results]
 
  * source code: [spec/serpapi/client/example/example_search_yelp_spec.rb](https://github.com/serpapi/serpapi-ruby/blob/master/spec/serpapi/client/example/example_search_yelp_spec.rb)
 see: [https://serpapi.com/yelp-search-api](https://serpapi.com/yelp-search-api)
-
-## Performance Comparison
-
-### Ruby 4.0.0 vs 3.4.4 vs Ruby 2.7.8 Performance
-
-| Metric | Ruby 2.7.8 | Ruby 3.4.4 | Ruby 4.0.0 | Improvement (3.4.4 vs 2.7.8) | Improvement (4.0.0 vs 3.4.4) |
-|--------|------------|------------|------------|------------------------------|------------------------------|
-| **SerpApi Non-Persistent** | 100.93 req/s | 114.97 req/s | 120.09 req/s | **+13.9%** | **+4.5%** |
-| **SerpApi Persistent** | 226.82 req/s | 255.07 req/s | 296.05 req/s | **+12.4%** | **+16.1%** |
-| **HTTP.rb Non-Persistent** | 270.62 req/s | 294.01 req/s | 319.81 req/s | **+8.6%** | **+8.8%** |
-| **HTTP.rb Persistent** | 347.04 req/s | 570.95 req/s | 456.93 req/s | **+64.5%** | **-20.0%** |
-
-### Key Takeaways
-1. **Upgrade to Ruby 3.4.4**: Clear performance benefits across all scenarios
-2. **Use Persistent Connections**: 2x+ performance improvement in most cases
-3. **HTTP.rb Performance**: Particularly benefits from Ruby 3.4.4 with persistent connections
-4. **SerpApi Optimization**: Shows consistent ~2.2x improvement with persistent connections regardless of Ruby version
-5. **Ruby 4.0.0 Performance**: Shows mixed results with some regressions compared to 3.4.4, particularly for HTTP.rb persistent connections. Ruby 4.0.0 was just released for Christmas 2025, and HTTP.rb has not been optimized for it yet.
-
-The older library (google-search-results-ruby) was performing at 55 req/s on Ruby 2.7.8, which is 2x slower than the current version (serpapi-ruby) on Ruby 3.4.4 or 4.0.0. 
-
-**Context** This benchmark was performed on warmup search results using a MacBook Pro 2025 connected via Wi-Fi 6.0 home network on AT&T fiber from Austin, TX (no network optimization). 
 
 ## Migration quick guide
 

--- a/README.md.erb
+++ b/README.md.erb
@@ -36,21 +36,22 @@ Query a vast range of data at scale, including web search results, flight schedu
 
 ## Installation
 
-Ruby 2.7 and higher are supported. To achieve an optimal performance, the latest version is recommended. Check 2.7.8 vs 3.4.4 [performance comparison](#Performance-Comparison).
+### RubyGems
 
-Other versions, such as Ruby 1.9, Ruby 2.x, and JRuby, are compatible with [legacy SerpApi library](https://github.com/serpapi/google-search-results-ruby), which is still supported. To upgrade to the latest library, check our [migration guide](#Migration-quick-guide).
-
-### Bundler
-```ruby
-gem 'serpapi', '~> 1.0', '>= 1.0.3'
-```
-
-### Gem
 ```bash
 $ gem install serpapi
 ```
 
-[Ruby Gem page](https://rubygems.org/gems/serpapi/)
+[RubyGems page](https://rubygems.org/gems/serpapi/)
+
+Ruby 2.7 and higher are supported. Other versions, such as Ruby 1.9, Ruby 2.x, and JRuby, are compatible with [legacy SerpApi library](https://github.com/serpapi/google-search-results-ruby), which is still supported. To upgrade to the latest library, check our [migration guide](#Migration-quick-guide).
+
+### Bundler
+
+```ruby
+# Gemfile
+gem 'serpapi', '~> 1.0', '>= 1.0.3'
+```
 
 ## Simple Usage
 
@@ -216,22 +217,6 @@ Note: `gem install connection_pool` to run this example.
 * Improved performance by avoiding the overhead of creating and destroying connections for each request.
 * Efficient use of resources by sharing connections among multiple threads.
 * Concurrency and parallelism, allowing multiple requests to be processed simultaneously.
-
-benchmark: (demo/demo_thread_pool.rb)
-
-** Benchmark Ruby 3.4.8 vs Ruby 4.0.0 **
-
-benchmark: (demo/demo_thread_pool.rb)
-
-| ruby | runtime (s) | thread | time/thread (s) |
-|------|------------:|-------:|----------------:|
-| 3.4.8 | 0.018644 | 4 | 0.004661 |
-| 4.0.0 | 0.017302 | 4 | 0.004326 |
-
-Ruby 4.0.0 shows a slight improvement over Ruby 3.4.8, but the difference is not significant using thread.
-Ractor could be considered for a more efficient use of resources but it's still in the experimental stage.
-
-Note: in this benchmark, `thread == HTTP connections`.
 
 ### Real world search without persistency
 
@@ -490,27 +475,6 @@ see: [https://serpapi.com/yandex-search-api](https://serpapi.com/yandex-search-a
 <%= snippet('ruby', 'spec/serpapi/client/example/example_search_yelp_spec.rb') %>
 see: [https://serpapi.com/yelp-search-api](https://serpapi.com/yelp-search-api)
 
-## Performance Comparison
-
-### Ruby 4.0.0 vs 3.4.4 vs Ruby 2.7.8 Performance
-
-| Metric | Ruby 2.7.8 | Ruby 3.4.4 | Ruby 4.0.0 | Improvement (3.4.4 vs 2.7.8) | Improvement (4.0.0 vs 3.4.4) |
-|--------|------------|------------|------------|------------------------------|------------------------------|
-| **SerpApi Non-Persistent** | 100.93 req/s | 114.97 req/s | 120.09 req/s | **+13.9%** | **+4.5%** |
-| **SerpApi Persistent** | 226.82 req/s | 255.07 req/s | 296.05 req/s | **+12.4%** | **+16.1%** |
-| **HTTP.rb Non-Persistent** | 270.62 req/s | 294.01 req/s | 319.81 req/s | **+8.6%** | **+8.8%** |
-| **HTTP.rb Persistent** | 347.04 req/s | 570.95 req/s | 456.93 req/s | **+64.5%** | **-20.0%** |
-
-### Key Takeaways
-1. **Upgrade to Ruby 3.4.4**: Clear performance benefits across all scenarios
-2. **Use Persistent Connections**: 2x+ performance improvement in most cases
-3. **HTTP.rb Performance**: Particularly benefits from Ruby 3.4.4 with persistent connections
-4. **SerpApi Optimization**: Shows consistent ~2.2x improvement with persistent connections regardless of Ruby version
-5. **Ruby 4.0.0 Performance**: Shows mixed results with some regressions compared to 3.4.4, particularly for HTTP.rb persistent connections. Ruby 4.0.0 was just released for Christmas 2025, and HTTP.rb has not been optimized for it yet.
-
-The older library (google-search-results-ruby) was performing at 55 req/s on Ruby 2.7.8, which is 2x slower than the current version (serpapi-ruby) on Ruby 3.4.4 or 4.0.0.
-
-**Context** This benchmark was performed on warmup search results using a MacBook Pro 2025 connected via Wi-Fi 6.0 home network on AT&T fiber from Austin, TX (no network optimization).
 
 ## Migration quick guide
 


### PR DESCRIPTION
I suggest not mixing up performance details directly into README especially since we now use as source for our integrations pages. We are talking about performance optimization even before letting people install the gem which might be confusing or suggest the gem is somehow slow. For now, I only decoupled the info into BENCHMARKS.md (feel free to suggest a different name for the file), I'll likely submit more changes regarding the text itself. Btw it's great we have benchmarks and care about performance, but we should invite people to try the gem first and foremost. We can point them to this level of optimization later.