### PR TITLE
Increase timeout to fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,8 @@ require 'serpapi'
 require 'connection_pool'
 
 # create a thread pool of 4 threads with a persistent connection to serpapi.com
-pool = ConnectionPool.new(size: n, timeout: 5) do
+# timeout is the connection checkout wait, so it must outlast an in-flight search
+pool = ConnectionPool.new(size: n, timeout: 60) do
   SerpApi::Client.new(engine: 'google', api_key: ENV['SERPAPI_KEY'], timeout: 30, persistent: true)
 end
 

--- a/README.md.erb
+++ b/README.md.erb
@@ -191,7 +191,8 @@ require 'serpapi'
 require 'connection_pool'
 
 # create a thread pool of 4 threads with a persistent connection to serpapi.com
-pool = ConnectionPool.new(size: n, timeout: 5) do
+# timeout is the connection checkout wait, so it must outlast an in-flight search
+pool = ConnectionPool.new(size: n, timeout: 60) do
   SerpApi::Client.new(engine: 'google', api_key: ENV['SERPAPI_KEY'], timeout: 30, persistent: true)
 end
 

--- a/demo/demo_thread_pool.rb
+++ b/demo/demo_thread_pool.rb
@@ -62,7 +62,8 @@ require 'connection_pool'
 n = 4
 runtime = Benchmark.measure do
   # create a thread pool of 4 threads with a persistent connection to serpapi.com
-  pool = ConnectionPool.new(size: n, timeout: 5) do
+  # timeout is the connection checkout wait, so it must outlast an in-flight search
+  pool = ConnectionPool.new(size: n, timeout: 60) do
     SerpApi::Client.new(engine: 'google',
                         api_key: ENV['SERPAPI_KEY'],
                         timeout: 30,


### PR DESCRIPTION
Currently our test suite fails at times running `demo/demo_thread_pool.rb`.

See https://github.com/serpapi/serpapi-ruby/actions/runs/31487463853/job/93766042099